### PR TITLE
Make sure assets are precompiled on Heroku

### DIFF
--- a/lib/active_admin/editor/engine.rb
+++ b/lib/active_admin/editor/engine.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
         def editor; ActiveAdmin::Editor.configuration end
       end
 
-      initializer 'active_admin.editor' do |app|
+      initializer 'active_admin.editor', :group => :all do |app|
         app.config.assets.precompile += [
           'active_admin/editor.js',
           'active_admin/editor.css'


### PR DESCRIPTION
Heroku recommends that `config.assets.initialize_on_precompile = false`,
which means that this initializer will not be invoked by
`rake assets:precompile`, which forces developers deploying to Heroku
to duplicate this initializer in their apps' configs.
