### PR TITLE
Remove deprecated box-shadow mixin from the Editor style.

### DIFF
--- a/app/assets/stylesheets/active_admin/editor.css.scss
+++ b/app/assets/stylesheets/active_admin/editor.css.scss
@@ -22,7 +22,7 @@ body form .html_editor {
     border-top: 1px solid lighten(#C9D0D6, 10%);
 
     &:focus {
-      @include box-shadow(none);
+      box-shadow: none;
       border: 1px solid #C9D0D6;
       border-top: 1px solid lighten(#C9D0D6, 10%);
     }


### PR DESCRIPTION
@ejholmes
Bourbon produces a deprecation warning message when I using the ActiveAdmin Editor.
See gregbell /active_admin/pull/1913

```
WARNING: box-shadow is deprecated and will be removed in the next major version release
    on line 7 of /app/vendor/bundle/ruby/2.0.0/gems/bourbon-3.1.8/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss, in `box-shadow'
    from line 25 of /app/vendor/bundle/ruby/2.0.0/gems/active_admin_editor-1.1.0/app/assets/stylesheets/active_admin/editor.css.scss
```
