### PR TITLE
Adds support for own toolbar and uploader templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,31 @@ Be sure to clear your rails cache after changing the config:
 rm -rf tmp/cache
 ```
 
+## Custom template paths
+The toolbar and the uploader are client side templates (ejs)
+To customize these you can set custom paths your very own templates.
+__Its important that the template has a different name then (toolbar or uploader)!__
+
+```ruby
+ActiveAdmin::Editor.configure do |config|
+  config.template_paths = {
+      toolbar: 'path to my custom toolbar template',
+      uploader: 'path to my custom uploader template'
+  }
+end
+```
+__Please check the original templates for an example__
+app/assets/javascripts/active_admin/editor/templates
+
+### Make your templates available
+Unfortunately sproket can not find templates from your
+asset folder when requireing them in a gem. So you have to
+make your templates manually avaliable.
+
+```javascript
+//= require_tree ./path_to_your_templates
+```
+
 ## Heroku
 
 Since some of the javascript files need to be compiled with access to the env

--- a/app/assets/javascripts/active_admin/editor/config.js.erb
+++ b/app/assets/javascripts/active_admin/editor/config.js.erb
@@ -10,4 +10,5 @@
   config.spinner = '<%= asset_path 'active_admin/editor/loader.gif' %>'
   config.uploads_enabled = <%= ActiveAdmin::Editor.configuration.s3_configured? %>
   config.parserRules = <%= ActiveAdmin::Editor.configuration.parser_rules.to_json %>
+  config.template_paths = <%= ActiveAdmin::Editor.configuration.template_paths.to_json %>
 })(window)

--- a/app/assets/javascripts/active_admin/editor/editor.js
+++ b/app/assets/javascripts/active_admin/editor/editor.js
@@ -27,7 +27,7 @@
    * necessary file inputs for uploading.
    */
   Editor.prototype._addToolbar = function() {
-    var template = JST['active_admin/editor/templates/toolbar']({
+    var template = JST[config.template_paths.toolbar]({
       id: this.$el.attr('id') + '-toolbar'
     })
 
@@ -47,12 +47,12 @@
    * Adds a file input attached to the supplied text input. And upload is
    * triggered if the source of the input is changed.
    *
-   * @input Text input to attach a file input to. 
+   * @input Text input to attach a file input to.
    */
   Editor.prototype._addUploader = function(input) {
     var $input = $(input)
 
-    var template = JST['active_admin/editor/templates/uploader']({ spinner: config.spinner })
+    var template = JST[config.template_paths.uploader]({ spinner: config.spinner })
     var $uploader = $(template)
 
     var $dialog = $input.closest('[data-wysihtml5-dialog]')

--- a/lib/active_admin/editor/config.rb
+++ b/lib/active_admin/editor/config.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
       end
 
       def stylesheets
-        @stylesheets ||= [ 'active_admin/editor/wysiwyg.css' ]
+        @stylesheets ||= [ 'active_admin/editor/wymiwyg.css' ]
       end
 
       def s3_configured?

--- a/lib/active_admin/editor/config.rb
+++ b/lib/active_admin/editor/config.rb
@@ -29,6 +29,7 @@ module ActiveAdmin
       # wysiwyg stylesheets that get included in the backend and the frontend.
       attr_accessor :stylesheets
 
+      # paths to client side templates in the asset pipeline
       attr_accessor :template_paths
 
       def storage_dir

--- a/lib/active_admin/editor/config.rb
+++ b/lib/active_admin/editor/config.rb
@@ -29,6 +29,8 @@ module ActiveAdmin
       # wysiwyg stylesheets that get included in the backend and the frontend.
       attr_accessor :stylesheets
 
+      attr_accessor :template_paths
+
       def storage_dir
         @storage_dir ||= 'uploads'
       end
@@ -49,6 +51,14 @@ module ActiveAdmin
 
       def parser_rules
         @parser_rules ||= PARSER_RULES.dup
+      end
+
+      def template_paths
+        defaults = {
+          toolbar: 'active_admin/editor/templates/toolbar',
+          uploader: 'active_admin/editor/templates/uploader'
+        }
+        @template_paths ? @template_paths.reverse_merge!(defaults) : defaults
       end
     end
   end

--- a/lib/active_admin/editor/config.rb
+++ b/lib/active_admin/editor/config.rb
@@ -41,7 +41,7 @@ module ActiveAdmin
       end
 
       def stylesheets
-        @stylesheets ||= [ 'active_admin/editor/wymiwyg.css' ]
+        @stylesheets ||= [ 'active_admin/editor/wysiwyg.css' ]
       end
 
       def s3_configured?

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -7,6 +7,10 @@ describe('Editor', function() {
     this.xhr = sinon.useFakeXMLHttpRequest()
     $('body').append(JST['templates/editor']())
     this.config = sinon.stub()
+    this.config.template_paths = {
+      toolbar: 'active_admin/editor/templates/toolbar',
+      uploader: 'active_admin/editor/templates/uploader'
+    }
     this.editor = new window.AA.Editor(this.config, $('.html_editor'))
   })
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -15,6 +15,10 @@ describe ActiveAdmin::Editor.configuration do
     its(:aws_access_secret) { should be_nil }
     its(:s3_bucket)         { should be_nil }
     its(:storage_dir)       { should eq 'uploads' }
+    its(:template_paths)    { should eq({
+      toolbar: 'active_admin/editor/templates/toolbar',
+      uploader: 'active_admin/editor/templates/uploader'
+    }) }
   end
 
   describe '.s3_configured?' do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -16,7 +16,7 @@ describe ActiveAdmin::Editor.configuration do
     its(:s3_bucket)         { should be_nil }
     its(:storage_dir)       { should eq 'uploads' }
   end
-  
+
   describe '.s3_configured?' do
     subject { configuration.s3_configured? }
 
@@ -26,7 +26,7 @@ describe ActiveAdmin::Editor.configuration do
 
       it { should be_false }
     end
-    
+
     context 'when key, secret and bucket are set' do
       before do
         configuration.aws_access_key_id = 'foo'
@@ -49,6 +49,32 @@ describe ActiveAdmin::Editor.configuration do
     it 'strips leading slashes' do
       configuration.storage_dir = '/uploads'
       expect(subject).to eq 'uploads'
+    end
+  end
+
+  describe '.template_paths' do
+    subject { configuration.template_paths }
+
+    it 'should have default uploader path' do
+      configuration.template_paths = { toolbar: "hallo" }
+      expect(subject[:uploader]).not_to be_nil
+    end
+
+    it 'should have default toolbar path' do
+      configuration.template_paths = { uploader: "hallo" }
+      expect(subject[:toolbar]).not_to be_nil
+    end
+
+    it 'should be possible to override options' do
+      opts = { toolbar: "toolbar", uploader: "uploader" }
+      configuration.template_paths = opts
+      expect(subject).to eq opts
+    end
+
+    it "sould be possible just to override one option" do
+      opts = { toolbar: "toolbar" }
+      configuration.template_paths = opts
+      expect(subject).to eq({ toolbar: "toolbar", uploader: "active_admin/editor/templates/uploader" })
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -8,6 +8,10 @@ describe ActiveAdmin::Editor.configuration do
     configuration.aws_access_secret = nil
     configuration.s3_bucket = nil
     configuration.storage_dir = 'uploads'
+    configuration.template_paths = {
+      toolbar: 'active_admin/editor/templates/toolbar',
+      uploader: 'active_admin/editor/templates/uploader'
+    }
   end
 
   context 'by default' do


### PR DESCRIPTION
Hi @ejholmes
I came across this great gem. But for my client its very important to customize the UI. So I just added the possibility to configure the templates "toolbar" and "uploader". I also added a description.
What do you thing about this?
## Custom template paths

The toolbar and the uploader are client side templates (ejs)
To customize these you can set custom paths your very own templates.
**Its important that the template has a different name then (toolbar or uploader)!**

``` ruby
ActiveAdmin::Editor.configure do |config|
  config.template_paths = {
      toolbar: 'path to my custom toolbar template',
      uploader: 'path to my custom uploader template'
  }
end
```

**Please check the original templates for an example**
app/assets/javascripts/active_admin/editor/templates
### Make your templates available

Unfortunately sproket can not find templates from your
asset folder when requireing them in a gem. So you have to
make your templates manually avaliable.

``` javascript
//= require_tree ./path_to_your_templates
```
