### PR TITLE
Fileupload custom action

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ Then add the following CORS configuration to the S3 bucket:
 </CORSConfiguration>
 ```
 
+## Uploads with custom uploader action
+
+You also can upload images via a own provided action. For example so you can preprocess the images. For this you have to set the uploader_action_path in the initializer. When you have set the S3 config and the uploader_action_path, the uploader_action_path will win.
+
+```ruby
+ActiveAdmin::Editor.configure do |config|
+  config.uploader_action_path = '/path/to/the/uploader'
+end
+```
+
+__pseudocode of an uploader action within active admin__
+
+```ruby
+collection_action :upload_image, :method => :post do
+  img = Uploader.new(image: params[:file])
+  img.uplaode
+
+  # IMPORTANT the image url must be set as the headers location porperty
+  render json: {location: img.remote_url} , location: img.remote_url
+end
+```
+
+
 ## Configuration
 
 You can configure the editor in the initializer installed with `rails g

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Then add the following CORS configuration to the S3 bucket:
 
 ## Uploads with custom uploader action
 
-You also can upload images via a own provided action. For example so you can preprocess the images. For this you have to set the uploader_action_path in the initializer. When you have set the S3 config and the uploader_action_path, the uploader_action_path will win.
+You also can upload images via a own provided action. For example when you want to preprocess the images. For this you have to set the uploader_action_path in the initializer. When you have set the S3 config and the uploader_action_path, the uploader_action_path will win.
 
 ```ruby
 ActiveAdmin::Editor.configure do |config|
@@ -94,8 +94,8 @@ __pseudocode of an uploader action within active admin__
 
 ```ruby
 collection_action :upload_image, :method => :post do
-  img = Uploader.new(image: params[:file])
-  img.uplaode
+  img = ImageUploader.new(image: params[:file])
+  img.upload
 
   # IMPORTANT the image url must be set as the headers location porperty
   render json: {location: img.remote_url} , location: img.remote_url

--- a/app/assets/javascripts/active_admin/editor/config.js.erb
+++ b/app/assets/javascripts/active_admin/editor/config.js.erb
@@ -10,5 +10,10 @@
   config.spinner = '<%= asset_path 'active_admin/editor/loader.gif' %>'
   config.uploads_enabled = <%= ActiveAdmin::Editor.configuration.uploads_enabled? %>
   config.parserRules = <%= ActiveAdmin::Editor.configuration.parser_rules.to_json %>
-  config.uploader_action_path = '<%= ActiveAdmin::Editor.configuration.uploader_action_path.to_s %>'
+
+  <% if path = ActiveAdmin::Editor.configuration.uploader_action_path %>
+    config.uploader_action_path = '<%= path.to_s %>'
+  <% else %>
+    config.uploader_action_path = null
+  <% end %>
 })(window)

--- a/app/assets/javascripts/active_admin/editor/config.js.erb
+++ b/app/assets/javascripts/active_admin/editor/config.js.erb
@@ -10,5 +10,5 @@
   config.spinner = '<%= asset_path 'active_admin/editor/loader.gif' %>'
   config.uploads_enabled = <%= ActiveAdmin::Editor.configuration.uploads_enabled? %>
   config.parserRules = <%= ActiveAdmin::Editor.configuration.parser_rules.to_json %>
-  config.uploader_action_path = '<%= ActiveAdmin::Editor.configuration.uploader_action_path.to_s
+  config.uploader_action_path = '<%= ActiveAdmin::Editor.configuration.uploader_action_path.to_s %>'
 })(window)

--- a/app/assets/javascripts/active_admin/editor/config.js.erb
+++ b/app/assets/javascripts/active_admin/editor/config.js.erb
@@ -8,6 +8,7 @@
 
   config.stylesheets = <%= ActiveAdmin::Editor.configuration.stylesheets.map { |stylesheet| asset_path stylesheet }.to_json %>
   config.spinner = '<%= asset_path 'active_admin/editor/loader.gif' %>'
-  config.uploads_enabled = <%= ActiveAdmin::Editor.configuration.s3_configured? %>
+  config.uploads_enabled = <%= ActiveAdmin::Editor.configuration.uploads_enabled? %>
   config.parserRules = <%= ActiveAdmin::Editor.configuration.parser_rules.to_json %>
+  config.uploader_action_path = '<%= ActiveAdmin::Editor.configuration.uploader_action_path.to_s
 })(window)

--- a/app/assets/javascripts/active_admin/editor/editor.js
+++ b/app/assets/javascripts/active_admin/editor/editor.js
@@ -101,9 +101,9 @@
    */
   Editor.prototype.upload = function(file, callback) {
     if (config.uploader_action_path == null) {
-      this.s3_upload(file, callback);
+      return this.s3_upload(file, callback)
     } else {
-      this.action_upload(file, callback);
+      return this.action_upload(file, callback)
     }
   }
 

--- a/app/assets/javascripts/active_admin/editor/editor.js
+++ b/app/assets/javascripts/active_admin/editor/editor.js
@@ -172,7 +172,7 @@
     fd.append('Content-Type', file.type)
     fd.append('file', file)
 
-    xhr.upload.addEventListener('progress', function(e) {
+    xhr.s3_upload.addEventListener('progress', function(e) {
       _this.loaded   = e.loaded
       _this.total    = e.total
       _this.progress = e.loaded / e.total

--- a/app/assets/javascripts/active_admin/editor/editor.js
+++ b/app/assets/javascripts/active_admin/editor/editor.js
@@ -47,7 +47,7 @@
    * Adds a file input attached to the supplied text input. And upload is
    * triggered if the source of the input is changed.
    *
-   * @input Text input to attach a file input to. 
+   * @input Text input to attach a file input to.
    */
   Editor.prototype._addUploader = function(input) {
     var $input = $(input)
@@ -94,13 +94,69 @@
   }
 
   /**
+   * Uploads a file to S3 or an custom action.
+   *
+   * @file The file to upload
+   * @callback A function to be called when the upload completes.
+   */
+  Editor.prototype.upload = function(file, callback) {
+    if (config.uploader_action_path == null) {
+      this.s3_upload(file, callback);
+    } else {
+      this.action_upload(file, callback);
+    }
+  }
+
+  /**
+   * Uploads a file to a confured action under config.uploader_action_path.
+   * When the upload is complete, calls callback with the location of the uploaded file.
+   *
+   * @file The file to upload
+   * @callback A function to be called when the upload completes.
+   */
+  Editor.prototype.action_upload = function(file, callback) {
+    var _this = this
+    _this._uploading(true)
+
+    var xhr = new XMLHttpRequest()
+      , fd = new FormData()
+
+    fd.append('_method', 'POST')
+    fd.append('authenticity_token', $('meta[name="csrf-token"]').attr('content'))
+    fd.append('file', file)
+
+    xhr.upload.addEventListener('progress', function(e) {
+      _this.loaded   = e.loaded
+      _this.total    = e.total
+      _this.progress = e.loaded / e.total
+    }, false)
+
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState != 4) { return }
+      _this._uploading(false)
+      if (xhr.status == 200) {
+        callback(xhr.getResponseHeader('Location'))
+      } else {
+        alert('Failed to upload file. Have you implemented action "' + config.uploader_action_path + '" correctly?')
+      }
+    }
+
+    xhr.open('POST', 'http://localhost:3000' + config.uploader_action_path, true)
+    xhr.send(fd)
+
+    return xhr
+  }
+
+  /**
+
+  /**
    * Uploads a file to S3. When the upload is complete, calls callback with the
    * location of the uploaded file.
    *
    * @file The file to upload
    * @callback A function to be called when the upload completes.
    */
-  Editor.prototype.upload = function(file, callback) {
+  Editor.prototype.s3_upload = function(file, callback) {
     var _this = this
     _this._uploading(true)
 

--- a/app/assets/javascripts/active_admin/editor/editor.js
+++ b/app/assets/javascripts/active_admin/editor/editor.js
@@ -125,7 +125,7 @@
     fd.append($('meta[name="csrf-param"]').attr('content'), $('meta[name="csrf-token"]').attr('content'))
     fd.append('file', file)
 
-    xhr.action_upload.addEventListener('progress', function(e) {
+    xhr.upload.addEventListener('progress', function(e) {
       _this.loaded   = e.loaded
       _this.total    = e.total
       _this.progress = e.loaded / e.total
@@ -173,7 +173,7 @@
     fd.append('Content-Type', file.type)
     fd.append('file', file)
 
-    xhr.s3_upload.addEventListener('progress', function(e) {
+    xhr.upload.addEventListener('progress', function(e) {
       _this.loaded   = e.loaded
       _this.total    = e.total
       _this.progress = e.loaded / e.total

--- a/app/assets/javascripts/active_admin/editor/editor.js
+++ b/app/assets/javascripts/active_admin/editor/editor.js
@@ -122,10 +122,10 @@
       , fd = new FormData()
 
     fd.append('_method', 'POST')
-    fd.append('authenticity_token', $('meta[name="csrf-token"]').attr('content'))
+    fd.append($('meta[name="csrf-param"]').attr('content'), $('meta[name="csrf-token"]').attr('content'))
     fd.append('file', file)
 
-    xhr.upload.addEventListener('progress', function(e) {
+    xhr.action_upload.addEventListener('progress', function(e) {
       _this.loaded   = e.loaded
       _this.total    = e.total
       _this.progress = e.loaded / e.total
@@ -141,7 +141,8 @@
       }
     }
 
-    xhr.open('POST', 'http://localhost:3000' + config.uploader_action_path, true)
+    action_url = window.location.protocol + '//' + window.location.host + config.uploader_action_path
+    xhr.open('POST', action_url, true)
     xhr.send(fd)
 
     return xhr

--- a/lib/active_admin/editor/config.rb
+++ b/lib/active_admin/editor/config.rb
@@ -29,6 +29,9 @@ module ActiveAdmin
       # wysiwyg stylesheets that get included in the backend and the frontend.
       attr_accessor :stylesheets
 
+      # action which should handle file upload
+      attr_accessor :uploader_action_path
+
       def storage_dir
         @storage_dir ||= 'uploads'
       end
@@ -49,6 +52,10 @@ module ActiveAdmin
 
       def parser_rules
         @parser_rules ||= PARSER_RULES.dup
+      end
+
+      def uploader_action_path=(action)
+        @uploader_action_path = (action.nil?) ? action : "/#{ action.to_s.gsub(/(^\/|\/$)/, '') }"
       end
     end
   end

--- a/lib/active_admin/editor/config.rb
+++ b/lib/active_admin/editor/config.rb
@@ -50,6 +50,10 @@ module ActiveAdmin
           s3_bucket.present?
       end
 
+      def uploads_enabled?
+        s3_configured? or @uploader_action_path.present?
+      end
+
       def parser_rules
         @parser_rules ||= PARSER_RULES.dup
       end

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -189,7 +189,8 @@ describe('Editor', function() {
       this.xhr.prototype.send = sinon.stub()
       this.config.uploader_action_path = '/path/to/action'
       xhr = this.editor.action_upload(sinon.stub(), function() {})
-      expect(xhr.open).to.have.been.calledWith('POST', 'http://localhost:3500/path/to/action', true)
+      action_url = window.location.protocol + '//' + window.location.host + this.config.uploader_action_path
+      expect(xhr.open).to.have.been.calledWith('POST', action_url, true)
     })
 
     it('sends the request', function() {

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -84,7 +84,7 @@ describe('Editor', function() {
 
   describe('.s3_upload', function() {
     beforeEach(function() {
-      this.xhr.prototype.s3_upload = { addEventListener: sinon.stub() }
+      this.xhr.prototype.upload = { addEventListener: sinon.stub() }
     })
 
     it('opens the connection to the proper bucket', function() {
@@ -181,7 +181,7 @@ describe('Editor', function() {
 
   describe('.action_upload', function() {
     beforeEach(function() {
-      this.xhr.prototype.action_upload = { addEventListener: sinon.stub() }
+      this.xhr.prototype.upload = { addEventListener: sinon.stub() }
     })
 
     it('opens the connection to the uploader action', function() {

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -82,6 +82,28 @@ describe('Editor', function() {
     })
   })
 
+  describe('.upload', function() {
+    it('calls s3_upload when uploader_action_path is not set', function() {
+      this.editor.s3_upload = sinon.stub()
+      this.editor.action_upload = sinon.stub()
+      this.config.s3_bucket = 'bucket'
+      this.config.uploader_action_path= null
+      xhr = this.editor.upload(sinon.stub(), function() {})
+      expect(this.editor.s3_upload).to.have.been.called
+      expect(this.editor.action_upload).not.to.have.been.called
+    })
+
+    it('calls action_upload when uploader_action_path is set', function() {
+      this.editor.s3_upload = sinon.stub()
+      this.editor.action_upload = sinon.stub()
+      this.config.s3_bucket = 'bucket'
+      this.config.uploader_action_path= '/uploader/action'
+      xhr = this.editor.upload(sinon.stub(), function() {})
+      expect(this.editor.s3_upload).not.to.have.been.called
+      expect(this.editor.action_upload).to.have.been.called
+    })
+  })
+
   describe('.s3_upload', function() {
     beforeEach(function() {
       this.xhr.prototype.upload = { addEventListener: sinon.stub() }

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -82,22 +82,22 @@ describe('Editor', function() {
     })
   })
 
-  describe('.upload', function() {
+  describe('.s3_upload', function() {
     beforeEach(function() {
-      this.xhr.prototype.upload = { addEventListener: sinon.stub() }
+      this.xhr.prototype.s3_upload = { addEventListener: sinon.stub() }
     })
 
     it('opens the connection to the proper bucket', function() {
       this.xhr.prototype.open = sinon.stub()
       this.xhr.prototype.send = sinon.stub()
       this.config.s3_bucket = 'bucket'
-      xhr = this.editor.upload(sinon.stub(), function() {})
+      xhr = this.editor.s3_upload(sinon.stub(), function() {})
       expect(xhr.open).to.have.been.calledWith('POST', 'https://bucket.s3.amazonaws.com', true)
     })
 
     it('sends the request', function() {
       this.xhr.prototype.send = sinon.stub()
-      xhr = this.editor.upload(sinon.stub(), function() {})
+      xhr = this.editor.s3_upload(sinon.stub(), function() {})
       expect(xhr.send).to.have.been.called
     })
 
@@ -106,7 +106,7 @@ describe('Editor', function() {
         this.xhr.prototype.open = sinon.stub()
         this.xhr.prototype.send = sinon.stub()
         this.config.s3_bucket = 'bucket'
-        xhr = this.editor.upload(sinon.stub(), function(location) {
+        xhr = this.editor.s3_upload(sinon.stub(), function(location) {
           expect(location).to.eq('foo')
           done()
         })
@@ -123,7 +123,7 @@ describe('Editor', function() {
         this.xhr.prototype.send = sinon.stub()
         this.config.s3_bucket = 'bucket'
         alert = sinon.stub()
-        xhr = this.editor.upload(sinon.stub(), function() {})
+        xhr = this.editor.s3_upload(sinon.stub(), function() {})
         xhr.readyState = 4
         xhr.status = 403
         xhr.onreadystatechange()
@@ -146,7 +146,7 @@ describe('Editor', function() {
         this.config.storage_dir       = 'uploads'
         this.config.aws_access_key_id = 'access key'
 
-        this.editor.upload(file, function() {})
+        this.editor.s3_upload(file, function() {})
       })
 
       it('sets "key"', function() {

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -178,4 +178,83 @@ describe('Editor', function() {
       })
     })
   })
+
+  describe('.action_upload', function() {
+    beforeEach(function() {
+      this.xhr.prototype.action_upload = { addEventListener: sinon.stub() }
+    })
+
+    it('opens the connection to the uploader action', function() {
+      this.xhr.prototype.open = sinon.stub()
+      this.xhr.prototype.send = sinon.stub()
+      this.config.uploader_action_path = '/path/to/action'
+      xhr = this.editor.action_upload(sinon.stub(), function() {})
+      expect(xhr.open).to.have.been.calledWith('POST', 'http://localhost:3500/path/to/action', true)
+    })
+
+    it('sends the request', function() {
+      this.xhr.prototype.send = sinon.stub()
+      xhr = this.editor.action_upload(sinon.stub(), function() {})
+      expect(xhr.send).to.have.been.called
+    })
+
+    describe('when the upload succeeds', function() {
+      it('calls the callback with the location', function(done) {
+        this.xhr.prototype.open = sinon.stub()
+        this.xhr.prototype.send = sinon.stub()
+        this.config.uploader_action_path = '/path/to/action'
+        xhr = this.editor.action_upload(sinon.stub(), function(location) {
+          expect(location).to.eq('foo')
+          done()
+        })
+        xhr.getResponseHeader = sinon.stub().returns('foo')
+        xhr.readyState = 4
+        xhr.status = 200
+        xhr.onreadystatechange()
+      })
+    })
+
+    describe('when the upload fails', function() {
+      it('shows an alert', function() {
+        this.xhr.prototype.open = sinon.stub()
+        this.xhr.prototype.send = sinon.stub()
+        this.config.uploader_action_path = '/path/to/action'
+        alert = sinon.stub()
+        xhr = this.editor.action_upload(sinon.stub(), function() {})
+        xhr.readyState = 4
+        xhr.status = 403
+        xhr.onreadystatechange()
+        expect(alert).to.have.been.calledWith('Failed to upload file. Have you implemented action "' + this.config.uploader_action_path + '" correctly?')
+      })
+    })
+
+    describe('form data', function() {
+      beforeEach(function() {
+        file = this.file = { name: 'foobar', type: 'image/jpg' }
+        append = this.append = sinon.stub()
+        FormData = function() { return { append: append } }
+
+        Date.now = function() { return { toString: function() { return '1234' } } }
+
+        this.xhr.prototype.open = sinon.stub()
+        this.xhr.prototype.send = sinon.stub()
+
+        this.config.uploader_action_path = '/path/to/action'
+
+        this.editor.action_upload(file, function() {})
+      })
+
+      it('sets "_method"', function() {
+        expect(this.append).to.have.been.calledWith('_method', 'POST')
+      })
+
+      it('sets "authenticy_token"', function() {
+        expect(this.append).to.have.been.calledWith('authenticity_token', 'aMmw0/cl9FYg9Xi/SLCcdR0PASH1QOJrlQNr9rJOQ4g=')
+      })
+
+      it('sets "file"', function() {
+        expect(this.append).to.have.been.calledWith('file', this.file)
+      })
+    })
+  })
 })

--- a/spec/javascripts/templates/editor.jst.ejs
+++ b/spec/javascripts/templates/editor.jst.ejs
@@ -1,3 +1,6 @@
+<meta content="aMmw0/cl9FYg9Xi/SLCcdR0PASH1QOJrlQNr9rJOQ4g=" name="csrf-token">
+<meta content="authenticity_token" name="csrf-param">
+
 <li class="html_editor input optional" data-policy="{&quot;document&quot;:&quot;policy document&quot;,&quot;signature&quot;:&quot;policy signature&quot;}" id="page_content_input">
     <label class=" label" for="page_content">Content</label>
     <div class="wrap">

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -8,6 +8,7 @@ describe ActiveAdmin::Editor.configuration do
     configuration.aws_access_secret = nil
     configuration.s3_bucket = nil
     configuration.storage_dir = 'uploads'
+    configuration.uploader_action_path = nil
   end
 
   context 'by default' do
@@ -15,8 +16,9 @@ describe ActiveAdmin::Editor.configuration do
     its(:aws_access_secret) { should be_nil }
     its(:s3_bucket)         { should be_nil }
     its(:storage_dir)       { should eq 'uploads' }
+    its(:uploader_action_path){ should be_nil }
   end
-  
+
   describe '.s3_configured?' do
     subject { configuration.s3_configured? }
 
@@ -26,7 +28,7 @@ describe ActiveAdmin::Editor.configuration do
 
       it { should be_false }
     end
-    
+
     context 'when key, secret and bucket are set' do
       before do
         configuration.aws_access_key_id = 'foo'
@@ -51,4 +53,19 @@ describe ActiveAdmin::Editor.configuration do
       expect(subject).to eq 'uploads'
     end
   end
+
+  describe ".uploader_action_path" do
+    subject { configuration.uploader_action_path }
+
+    it 'strips trailing slashes' do
+      configuration.uploader_action_path = '/action/'
+      expect(subject).to eq '/action'
+    end
+
+    it 'add leading slash' do
+      configuration.uploader_action_path= 'action'
+      expect(subject).to eq '/action'
+    end
+  end
+
 end


### PR DESCRIPTION
Hi @ejholmes

Here another feature. I just added the possibility also to provide an custom uploader action. I added this because I like to scale down images before they gets saved at S3. I just don't believe enough in the editors that they don't put a 3MB Image in. All the tests still run and new ones are added.

``` ruby
ActiveAdmin::Editor.configure do |config|
  config.uploader_action_path = '/admin/posts/upload_image'
end
```

example action

``` ruby
collection_action :upload_image, :method => :post do
  img = ImageUploader.new(image: params[:file])
  img.upload

  # IMPORTANT the image url must be set as the headers location porperty
  render json: {location: img.remote_url} , location: img.remote_url
end
```

Cheers
