### PR TITLE
Don't parse pasted content in textarea mode (fixes #35)

### DIFF
--- a/vendor/assets/javascripts/wysihtml5.js
+++ b/vendor/assets/javascripts/wysihtml5.js
@@ -9509,13 +9509,6 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
           that.parse(that.composer.element);
         }, keepScrollPosition);
       });
-      
-      this.observe("paste:textarea", function() {
-        var value   = this.textarea.getValue(),
-            newValue;
-        newValue = this.parse(value);
-        this.textarea.setValue(newValue);
-      });
     }
   });
 })(wysihtml5);


### PR DESCRIPTION
This change reflects [changes to wysihtml5](https://github.com/xing/wysihtml5/commit/82d3a0eac002e551244a678f0ca44c8f16402f02) that will be released with version 0.4.0. This is a temporary fix until version 0.4.0 is released.
