### PR TITLE
Fix invalid gemspec for activeadmin dependency

### DIFF
--- a/active_admin_editor.gemspec
+++ b/active_admin_editor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '>= 3.0.0'
-  s.add_dependency 'activeadmin', '>= 0.4.0'
+  s.add_dependency 'activeadmin', '>= 0.4.3'
   s.add_dependency 'ejs'
 
   s.add_development_dependency 'sqlite3'
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'database_cleaner', '~> 0.9.1'
   s.add_development_dependency 'capybara', '~> 1.1.4'
-  s.add_development_dependency 'activeadmin', '~> 0.4.3'
   s.add_development_dependency 'poltergeist', '~> 1.0.2'
   s.add_development_dependency 'faker'
 


### PR DESCRIPTION
After updating to ruby 2.1.1 Bundler started complaining about duplicate dependency definitions:

```
The validation message from Rubygems was:
  duplicate dependency on activeadmin (~> 0.4.3, development), (>= 0.4.0) use:
    add_runtime_dependency 'activeadmin', '~> 0.4.3', '>= 0.4.0'
```

This fixes it.
