### PR TITLE
Restore deprecated mixin box-shadow

### DIFF
--- a/app/assets/stylesheets/active_admin/editor.css.scss
+++ b/app/assets/stylesheets/active_admin/editor.css.scss
@@ -1,5 +1,11 @@
 @import 'active_admin/mixins';
 
+@mixin box-shadow($value) {
+    -webkit-box-shadow: $value;
+    -moz-box-shadow: $value;
+    box-shadow: $value;
+}
+
 body form .html_editor {
   .wrap {
     width: 76%;


### PR DESCRIPTION
The absence of box-shadow mixing causes the following error message :

Undefined mixing 'box-shadow' with Active Admin Editor

Its could be solve adding the mixing again.
